### PR TITLE
Moved statistics toggle state into chart store.

### DIFF
--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -79,7 +79,7 @@
     </v-row>
   </v-container>
 </template>
-
+ 
 <script setup>
 import { Filler } from 'chart.js'
 import { Line } from 'vue-chartjs'
@@ -113,15 +113,6 @@ let chartData = ref(chartStore.nodeChartData)
 let xLabel = 'Distance from outlet (m)'
 let yLabel = `${props.chosenPlot?.name} (${props.chosenPlot?.unit})`
 let title = `${props.data.title}: ${props.chosenPlot?.name} vs Distance`
-
-// TODO: remove this console.log
-console.log('showStatistics', showStatistics.value)
-
-
-//if (showStatistics.value == true) {
-//  // we need to recompue the statistics based on the data that is currently visible
-//  toggleSeriesStatistics(true)
-//}
 
 
 //onMounted(() => {

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -24,21 +24,14 @@
                     plot.</v-tooltip>
                 </div>
 
-                <DataQuality
-                  v-model="dataQuality"
-                  id="dataQuality"
-                  :data="chartStore.nodeChartData"
-                  @qualityUpdated="filterAllDatasets"
-                />
+                <DataQuality v-model="dataQuality" id="dataQuality" :data="chartStore.nodeChartData"
+                  @qualityUpdated="filterAllDatasets" />
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>
-          <v-select
-            label="Plot Style"
-            v-model="showLine"
-            :items="[{title: 'Scatter', value: false}, {title: 'Connected', value: true}]"
-            @update:modelValue="chartStore.updateShowLine"
-          >
+          <v-select label="Plot Style" v-model="showLine"
+            :items="[{ title: 'Scatter', value: false }, { title: 'Connected', value: true }]"
+            @update:modelValue="chartStore.updateShowLine">
           </v-select>
           <v-btn :loading="downloading.chart" @click="downloadChart()" class="ma-1" color="input">
             <v-icon :icon="mdiDownloadBox"></v-icon>
@@ -88,7 +81,7 @@ const chartStore = useChartsStore()
 const props = defineProps({ data: Object, chosenPlot: Object })
 const downloading = ref({ csv: false, json: false, chart: false })
 const dataQuality = ref([0, 1, 2, 3])
-const { plotStyle, nodeChart, showStatistics } = storeToRefs(chartStore)
+const { nodeChartData, showStatistics, showLine } = storeToRefs(chartStore)
 const chartStatistics = ref(null)
 const nodeChart = ref(null)
 const timeRef = ref()

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -6,14 +6,16 @@
           :min-height="lgAndUp ? '65vh' : '50vh'"
           :max-height="lgAndUp ? '100%' : '20vh'"
           max-width="100%"
-          min-width="500px">
+          min-width="500px"
+        >
           <Line :data="chartData" :options="options" ref="nodeChart" :plugins="[Filler]" />
         </v-sheet>
         <v-sheet class="pa-2" color="input">
           <TimeRangeSlider 
             ref="timeRef" 
             @update="timeSliderUpdated"
-            @updateComplete="timeRangeUpdateComplete" />
+            @updateComplete="timeRangeUpdateComplete"
+          />
         </v-sheet>
       </v-col>
       <v-col>
@@ -23,22 +25,24 @@
               <v-expansion-panel-title> Series Options </v-expansion-panel-title>
               <v-expansion-panel-text>
                 <div>
-                  <v-switch 
+                  <v-switch
                     label="Statistics"
                     v-model="showStatistics"
                     color="primary"
-                    @change="toggleSeriesStatistics(showStatistics)">
+                    @change="toggleSeriesStatistics(showStatistics)"
+                  >
                     ></v-switch>
                   <v-tooltip activator="parent" location="start">
-                    Enable/Disable computed statistics in the long-profile plot.
-                  </v-tooltip>
+                    Enable/Disable computed statistics in the long-profile plot.</v-tooltip
+                  >
                 </div>
 
                 <DataQuality 
                   v-model="dataQuality"
                   id="dataQuality"
                   :data="chartStore.nodeChartData"
-                  @qualityUpdated="filterAllDatasets" />
+                  @qualityUpdated="filterAllDatasets"
+                />
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>
@@ -46,7 +50,8 @@
             label="Plot Style"
             v-model="showLine"
             :items="[{ title: 'Scatter', value: false }, { title: 'Connected', value: true }]"
-            @update:modelValue="chartStore.updateShowLine">
+            @update:modelValue="chartStore.updateShowLine"
+          >
           </v-select>
           <v-btn :loading="downloading.chart" @click="downloadChart()" class="ma-1" color="input">
             <v-icon :icon="mdiDownloadBox"></v-icon>

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -11,8 +11,8 @@
           <Line :data="chartData" :options="options" ref="nodeChart" :plugins="[Filler]" />
         </v-sheet>
         <v-sheet class="pa-2" color="input">
-          <TimeRangeSlider 
-            ref="timeRef" 
+          <TimeRangeSlider
+            ref="timeRef"
             @update="timeSliderUpdated"
             @updateComplete="timeRangeUpdateComplete"
           />
@@ -31,13 +31,14 @@
                     color="primary"
                     @change="toggleSeriesStatistics(showStatistics)"
                   >
-                    ></v-switch>
+                    ></v-switch
+                  >
                   <v-tooltip activator="parent" location="start">
                     Enable/Disable computed statistics in the long-profile plot.</v-tooltip
                   >
                 </div>
 
-                <DataQuality 
+                <DataQuality
                   v-model="dataQuality"
                   id="dataQuality"
                   :data="chartStore.nodeChartData"
@@ -49,7 +50,7 @@
           <v-select
             label="Plot Style"
             v-model="showLine"
-            :items="[{ title: 'Scatter', value: false }, { title: 'Connected', value: true }]"
+            :items="[{title: 'Scatter', value: false}, {title: 'Connected', value: true}]"
             @update:modelValue="chartStore.updateShowLine"
           >
           </v-select>

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -93,6 +93,8 @@ import { useChartsStore } from '@/stores/charts'
 import { APP_API_URL } from '@/constants'
 import { storeToRefs } from 'pinia'
 import { mdiEraser, mdiFileDelimited, mdiCodeJson, mdiDownloadBox, mdiMagnifyMinusOutline } from '@mdi/js'
+import { onMounted, onUpdated } from "vue"
+
 
 const { lgAndUp } = useDisplay()
 
@@ -100,9 +102,8 @@ const chartStore = useChartsStore()
 
 const props = defineProps({ data: Object, chosenPlot: Object })
 const downloading = ref({ csv: false, json: false, chart: false })
-const showStatistics = ref(false)
 const dataQuality = ref([0, 1, 2, 3])
-const { plotStyle, nodeChart } = storeToRefs(chartStore)
+const { plotStyle, nodeChart, showStatistics } = storeToRefs(chartStore)
 const chartStatistics = ref(null)
 const timeRef = ref()
 
@@ -113,11 +114,31 @@ let xLabel = 'Distance from outlet (m)'
 let yLabel = `${props.chosenPlot?.name} (${props.chosenPlot?.unit})`
 let title = `${props.data.title}: ${props.chosenPlot?.name} vs Distance`
 
+// TODO: remove this console.log
+console.log('showStatistics', showStatistics.value)
+
+
+//if (showStatistics.value == true) {
+//  // we need to recompue the statistics based on the data that is currently visible
+//  toggleSeriesStatistics(true)
+//}
+
+
+//onMounted(() => {
+//  if (showStatistics.value == true) {
+//    // we need to recompue the statistics based on the data that is currently visible
+//    toggleSeriesStatistics(true)
+//  }
+//
+//})
+
 const setDefaults = () => {
   // sets page elements back to their default values.
 
-  // set statistics switch to off
-  showStatistics.value = false
+  // set statistics switch to off in the charts store
+  chartStore.showStatistics = false
+//  showStatistics.value = false // TODO: remove this line
+
 }
 
 const setParsing = (datasets) => {
@@ -370,7 +391,6 @@ async function getStatistics() {
   // compute statistics based on the node series that are visible
   // in the chart.
 
-  //let datasets = chartStore.nodeChartData.datasets
   let datasets = chartStore.nodeChartData.datasets
     .filter((s) => s.seriesType == 'swot_node_series')
     .filter((s) => s.hidden == false)
@@ -428,7 +448,7 @@ const generateStatisticsSeries = async () => {
       let series = buildChartSeries(
         chartStatistics.value[stat],
         'p_dist_out',
-        props.chosenPlot.abbreviation,
+        props.chosenPlot.yvar.abbreviation,
         stat,
         { fill: false, hidden: false }
       )
@@ -438,7 +458,7 @@ const generateStatisticsSeries = async () => {
       let series = buildChartSeries(
         chartStatistics.value[stat],
         'p_dist_out',
-        props.chosenPlot.abbreviation,
+        props.chosenPlot.yvar.abbreviation,
         'IQR',
         { showLine: true, borderColor: 'gray', borderWidth: 1, pointRadius: 0 }
       )
@@ -448,7 +468,7 @@ const generateStatisticsSeries = async () => {
       let series = buildChartSeries(
         chartStatistics.value[stat],
         'p_dist_out',
-        props.chosenPlot.abbreviation,
+        props.chosenPlot.yvar.abbreviation,
         stat,
         {
           fill: '-1',
@@ -468,7 +488,7 @@ const generateStatisticsSeries = async () => {
 
 const toggleSeriesStatistics = async (visible = true) => {
   // adds and removes computed statistics from the chart
-
+  
   // get the data from the chart
   let updatedDatasets = nodeChart.value.chart.data.datasets
 

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -2,20 +2,12 @@
   <v-container class="overflow-auto">
     <v-row>
       <v-col xs="12" lg="9">
-        <v-sheet
-          :min-height="lgAndUp ? '65vh' : '50vh'"
-          :max-height="lgAndUp ? '100%' : '20vh'"
-          max-width="100%"
-          min-width="500px"
-        >
+        <v-sheet :min-height="lgAndUp ? '65vh' : '50vh'" :max-height="lgAndUp ? '100%' : '20vh'" max-width="100%"
+          min-width="500px">
           <Line :data="chartData" :options="options" ref="nodeChart" :plugins="[Filler]" />
         </v-sheet>
         <v-sheet class="pa-2" color="input">
-          <TimeRangeSlider
-            ref="timeRef"
-            @update="timeSliderUpdated"
-            @updateComplete="timeRangeUpdateComplete"
-          />
+          <TimeRangeSlider ref="timeRef" @update="timeSliderUpdated" @updateComplete="timeRangeUpdateComplete" />
         </v-sheet>
       </v-col>
       <v-col>
@@ -25,34 +17,20 @@
               <v-expansion-panel-title> Series Options </v-expansion-panel-title>
               <v-expansion-panel-text>
                 <div>
-                  <v-switch
-                    label="Statistics"
-                    v-model="showStatistics"
-                    color="primary"
-                    @change="toggleSeriesStatistics(showStatistics)"
-                  >
-                    ></v-switch
-                  >
-                  <v-tooltip activator="parent" location="start"
-                    >Enable/Disable computed statistics in the long-profile plot.</v-tooltip
-                  >
+                  <v-switch label="Statistics" v-model="showStatistics" color="primary"
+                    @change="toggleSeriesStatistics(showStatistics)">
+                    ></v-switch>
+                  <v-tooltip activator="parent" location="start">Enable/Disable computed statistics in the long-profile
+                    plot.</v-tooltip>
                 </div>
 
-                <DataQuality
-                  v-model="dataQuality"
-                  id="dataQuality"
-                  :data="chartStore.chartData"
-                  @qualityUpdated="filterAllDatasets"
-                />
+                <DataQuality v-model="dataQuality" id="dataQuality" :data="chartStore.chartData"
+                  @qualityUpdated="filterAllDatasets" />
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>
-          <v-select
-            label="Plot Style"
-            v-model="plotStyle"
-            :items="['Scatter', 'Connected']"
-            @update:modelValue="chartStore.updateChartLine(nodeChart)"
-          >
+          <v-select label="Plot Style" v-model="plotStyle" :items="['Scatter', 'Connected']"
+            @update:modelValue="chartStore.updateChartLine(nodeChart)">
           </v-select>
           <v-btn :loading="downloading.chart" @click="downloadChart()" class="ma-1" color="input">
             <v-icon :icon="mdiDownloadBox"></v-icon>
@@ -79,7 +57,7 @@
     </v-row>
   </v-container>
 </template>
- 
+
 <script setup>
 import { Filler } from 'chart.js'
 import { Line } from 'vue-chartjs'
@@ -93,7 +71,6 @@ import { useChartsStore } from '@/stores/charts'
 import { APP_API_URL } from '@/constants'
 import { storeToRefs } from 'pinia'
 import { mdiEraser, mdiFileDelimited, mdiCodeJson, mdiDownloadBox, mdiMagnifyMinusOutline } from '@mdi/js'
-import { onMounted, onUpdated } from "vue"
 
 
 const { lgAndUp } = useDisplay()
@@ -114,21 +91,11 @@ let xLabel = 'Distance from outlet (m)'
 let yLabel = `${props.chosenPlot?.name} (${props.chosenPlot?.unit})`
 let title = `${props.data.title}: ${props.chosenPlot?.name} vs Distance`
 
-
-//onMounted(() => {
-//  if (showStatistics.value == true) {
-//    // we need to recompue the statistics based on the data that is currently visible
-//    toggleSeriesStatistics(true)
-//  }
-//
-//})
-
 const setDefaults = () => {
   // sets page elements back to their default values.
 
   // set statistics switch to off in the charts store
-  chartStore.showStatistics = false
-//  showStatistics.value = false // TODO: remove this line
+  showStatistics.value = false // TODO: remove this line
 
 }
 
@@ -479,7 +446,7 @@ const generateStatisticsSeries = async () => {
 
 const toggleSeriesStatistics = async (visible = true) => {
   // adds and removes computed statistics from the chart
-  
+
   // get the data from the chart
   let updatedDatasets = nodeChart.value.chart.data.datasets
 

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -110,7 +110,7 @@ const setDefaults = () => {
   // sets page elements back to their default values.
 
   // set statistics switch to off in the charts store
-  showStatistics.value = false // TODO: remove this line
+  showStatistics.value = false
 
 }
 

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -2,12 +2,18 @@
   <v-container class="overflow-auto">
     <v-row>
       <v-col xs="12" lg="9">
-        <v-sheet :min-height="lgAndUp ? '65vh' : '50vh'" :max-height="lgAndUp ? '100%' : '20vh'" max-width="100%"
+        <v-sheet
+          :min-height="lgAndUp ? '65vh' : '50vh'"
+          :max-height="lgAndUp ? '100%' : '20vh'"
+          max-width="100%"
           min-width="500px">
           <Line :data="chartData" :options="options" ref="nodeChart" :plugins="[Filler]" />
         </v-sheet>
         <v-sheet class="pa-2" color="input">
-          <TimeRangeSlider ref="timeRef" @update="timeSliderUpdated" @updateComplete="timeRangeUpdateComplete" />
+          <TimeRangeSlider 
+            ref="timeRef" 
+            @update="timeSliderUpdated"
+            @updateComplete="timeRangeUpdateComplete" />
         </v-sheet>
       </v-col>
       <v-col>
@@ -17,19 +23,28 @@
               <v-expansion-panel-title> Series Options </v-expansion-panel-title>
               <v-expansion-panel-text>
                 <div>
-                  <v-switch label="Statistics" v-model="showStatistics" color="primary"
+                  <v-switch 
+                    label="Statistics"
+                    v-model="showStatistics"
+                    color="primary"
                     @change="toggleSeriesStatistics(showStatistics)">
                     ></v-switch>
-                  <v-tooltip activator="parent" location="start">Enable/Disable computed statistics in the long-profile
-                    plot.</v-tooltip>
+                  <v-tooltip activator="parent" location="start">
+                    Enable/Disable computed statistics in the long-profile plot.
+                  </v-tooltip>
                 </div>
 
-                <DataQuality v-model="dataQuality" id="dataQuality" :data="chartStore.nodeChartData"
+                <DataQuality 
+                  v-model="dataQuality"
+                  id="dataQuality"
+                  :data="chartStore.nodeChartData"
                   @qualityUpdated="filterAllDatasets" />
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>
-          <v-select label="Plot Style" v-model="showLine"
+          <v-select
+            label="Plot Style"
+            v-model="showLine"
             :items="[{ title: 'Scatter', value: false }, { title: 'Connected', value: true }]"
             @update:modelValue="chartStore.updateShowLine">
           </v-select>

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -33,8 +33,8 @@
                   >
                     ></v-switch
                   >
-                  <v-tooltip activator="parent" location="start">
-                    Enable/Disable computed statistics in the long-profile plot.</v-tooltip
+                  <v-tooltip activator="parent" location="start"
+                    >Enable/Disable computed statistics in the long-profile plot.</v-tooltip
                   >
                 </div>
 

--- a/frontend/src/components/TimeRangeSlider.vue
+++ b/frontend/src/components/TimeRangeSlider.vue
@@ -100,11 +100,13 @@ const setInitialState = () => {
   // set the initial state for the time ranges based
   // off available data.
   let offset = 2 * 86400 // 2 days in seconds. This is chosen arbitrarily
+
+  // compute min/max date based on the datasets, omitting computed_series (i.e. derived data)
   let minDateSec =
-    Math.min(...chartStore.nodeChartData.datasets.map((series) => series.minDateTime)) / 1000 -
+    Math.min(...chartStore.nodeChartData.datasets.filter(series => series.seriesType != 'computed_series').map((series) => series.minDateTime)) / 1000 -
     offset
   let maxDateSec =
-    Math.max(...chartStore.nodeChartData.datasets.map((series) => series.maxDateTime)) / 1000 +
+    Math.max(...chartStore.nodeChartData.datasets.filter(series => series.seriesType != 'computed_series').map((series) => series.maxDateTime)) / 1000 +
     offset
   timeRange.value = [minDateSec, maxDateSec]
   featuresStore.minTime = minDateSec

--- a/frontend/src/stores/charts.js
+++ b/frontend/src/stores/charts.js
@@ -16,7 +16,6 @@ export const useChartsStore = defineStore('charts', () => {
   const showChart = ref(false)
   const hasNodeData = ref(false)
   const chartTab = ref('timeseries')
-  const plotStyle = ref('Scatter')
   const showStatistics = ref(false)
   const showLine = ref(false)
 
@@ -636,11 +635,10 @@ export const useChartsStore = defineStore('charts', () => {
   }
 
   const storeMountedChart = (chart) => {
-    console.log('Number of stored charts (before)', storedCharts.value.length)
     storedCharts.value.push(chart)
 
+    // clean stored charts that are undifined
     cleanStoredCharts()
-    console.log('Number of stored charts (after)', storedCharts.value.length)
 
   }
 
@@ -671,7 +669,6 @@ export const useChartsStore = defineStore('charts', () => {
     chartTab,
     nodeCharts,
     reachCharts,
-    plotStyle,
     showStatistics,
     showLine,
     updateShowLine,

--- a/frontend/src/stores/charts.js
+++ b/frontend/src/stores/charts.js
@@ -18,6 +18,7 @@ export const useChartsStore = defineStore('charts', () => {
   const hasNodeData = ref(false)
   const chartTab = ref('timeseries')
   const plotStyle = ref('Scatter')
+  const showStatistics = ref(false)
 
   const dataQualityOptions = [
     { value: 0, label: 'good', pointStyle: 'circle', pointBorderColor: 'white', icon: mdiCircle },
@@ -669,5 +670,6 @@ export const useChartsStore = defineStore('charts', () => {
     updateChartLine,
     lineChart,
     nodeChart,
+    showStatistics
   }
 })

--- a/frontend/src/stores/charts.js
+++ b/frontend/src/stores/charts.js
@@ -636,8 +636,19 @@ export const useChartsStore = defineStore('charts', () => {
   }
 
   const storeMountedChart = (chart) => {
+    console.log('Number of stored charts (before)', storedCharts.value.length)
     storedCharts.value.push(chart)
+
+    cleanStoredCharts()
+    console.log('Number of stored charts (after)', storedCharts.value.length)
+
   }
+
+  const cleanStoredCharts = () => {
+    storedCharts.value = storedCharts.value.filter(e => e.chart != undefined) ;
+
+  }
+
 
   return {
     updateChartData,
@@ -661,10 +672,7 @@ export const useChartsStore = defineStore('charts', () => {
     nodeCharts,
     reachCharts,
     plotStyle,
-    updateChartLine,
-    lineChart,
-    nodeChart,
-    showStatistics
+    showStatistics,
     showLine,
     updateShowLine,
     storeMountedChart


### PR DESCRIPTION
Changes
- moved the state of the statistics toggle button into the chart store so that its state can be shared across all plots.
- auto linting and formatting 
- adjusted time range computation to ignore compute series such as statistics.