### PR TITLE
Clean up both the default and extended static metadata

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "marked": "^14.1.3",
         "pinia": "^2.1.6",
         "pinia-plugin-persistedstate": "^4.1.3",
-        "swagger-ui": "5.9.0",
+        "swagger-ui": "^5.18.2",
         "vite-plugin-vuetify": "^1.0.2",
         "vue": "^3.3.4",
         "vue-chartjs": "^5.3.0",
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@mdi/font": "^7.3.67",
-        "@mdi/js": "^7.3.67",
+        "@mdi/js": "^7.4.47",
         "@rushstack/eslint-patch": "^1.3.3",
         "@vitejs/plugin-vue": "^4.3.4",
         "@vue/eslint-config-prettier": "^8.0.0",
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
-      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.4.tgz",
+      "integrity": "sha512-hPYRrKFoI+nuckPgDJfyYAkybFvheo4usS0Vw0HNAe+fmGBQA5Az37b/yStO284atBoqqdOUhKJ3d9Zw3PQkcQ==",
       "license": "MIT"
     },
     "node_modules/@colors/colors": {
@@ -1002,7 +1002,8 @@
       "version": "7.4.47",
       "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1152,6 +1153,13 @@
       "integrity": "sha512-UY+FGM/2jjMkzQLn8pxcHGMaVLh9aEitG3zY2CiY7XHdLiz3bZOwa6oDxNqEMv7zZkV+cj5DOdz0cQ1BP5Hjgw==",
       "dev": true
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -1186,13 +1194,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-f4Y9t1oBlnsvMoLPCykzn5LRrmARiaPzorocQkMFTkYUPb7RKA4zCuWi67hH4iDVsVvkPutgew19XyJiI3OF9Q==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-beta.3.tgz",
+      "integrity": "sha512-JOXGfadL3ucJH+MY9BDT7dJOwFy0jX3XaAY/CWR92EnliEYfaEzZvH08FGnyqyYHcfT8T0DLKna5CWUHaskZuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1200,14 +1208,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-4uXIN8cLigD1SZUDhmrEwW+1zbrB6bbD9Hlpo/BF74t/Nh4ZoEOUXv1oR/8QXB9AsIkdO65FdDHyaPzyGbjMiQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-beta.3.tgz",
+      "integrity": "sha512-oRcv3PgwSAvfxvai0afGt/rC2Kk9Zs2ArLPZ6FnVCv/GSnMsuvIQJc5UH29P9eGFcLJIZpQtEHnU6W+u8u0zAA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
@@ -1217,39 +1225,39 @@
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-ydHNOKTdp9jaeW2yBvdZazXNCVFPbzC2Dy3dtDWU3MwUtSryoefT9OUQFWL7NxzChFRneNhBEcVl4NRocitXeA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-beta.3.tgz",
+      "integrity": "sha512-cW1tzehphuxA0uM+1m4/0G1d/WjDQyF+RL9D9t1mfhuVxr8AorgYUgY+bjg0pkLfiSTwjrDiuTbYM+jZwrHx8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-Xo0v4Jxp0ZiAm+OOL2PSLyjiw5OAkCMxI0nN9+vOw1/mfXcC+tdb30QQ9WNtF7O9LExjznfFID/NnDEYqBRDwA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-beta.3.tgz",
+      "integrity": "sha512-r6Gvbj2XDcK1wIULoclHcGYPAVXeUkj5ECRslB/Zle/fOU0Jb8s4mmFARyQE/DT+fQggXn8nUJBda3NWPK4GcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-0i4KKNboHi7F8Nra2WNHDl9aOndyTcfKiBfdzSw3j+H5wYAHldeKg7zppqj5rVfwZL9pB5r7eFYZlowwGtmlLg==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-beta.3.tgz",
+      "integrity": "sha512-x+NiLR0xZ0VB8AMJr7ii+6A27AP2CGjLyPQr6JutnifXG+vpkjbgXCPyz2qlmrvuLIkBJIE2lBuyX3+qQXmgCw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1257,15 +1265,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-d1LLJ/9LQaT/4jJudFhy3xhpjdTA3pVwBBUqXGPgW2Fp21auTYJMBM9J91wvVUXMUQiVg95DohkCb6TNUYzqLw==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-beta.3.tgz",
+      "integrity": "sha512-9E4/kTf/OzV3vgRjZOB+6TRqQX2ljirD+UBQ8QPSJKBUTtq8+F7U9a8Z9AGYrKCQUMgbge5JMYCqHmOmrJKVUA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1273,14 +1281,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-sNj4pAmxEfFYIqRcP9A7/gjNMaa7nu1pWT6gTMXtYROyo4XrChc3wit8F76WJEFIiEPLrPs2SrnnA5GIHM7EnA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Sc/ywYCHFIMwhZX0Yo+OTmHUvszv3JE3xsvpd18nu7rH+jNyA10oUdTMgnRsTNMnL7siVO+32OKQkdLOSKsEHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.3",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1288,16 +1296,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-Okwi0ikBSIBhQwMvsoe1+8Ff55cwwp9hu88N/sTDBxI7lyX0xCGAlSrJ9tx4Z/uOn5X+IL9HCRuNlbFt4Bvi2w==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-beta.3.tgz",
+      "integrity": "sha512-UuGfaJfWzsTCTEyxyKtM86SNdS4EsWB/+j8JWw88h7nFK59YNDmnuXk9PpFyuccpIAHnDq7UJypD3lRvNkJdhQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1305,16 +1313,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-Y5p+iA1k8HR5d5cS1jtoADPKJLVg5czaHrs39UcMoMPhINqgqKGd2sYKtX7DnglcLARXe06pv0Qs9ERwCd5ayQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-beta.3.tgz",
+      "integrity": "sha512-7Snaf8/qZ3Q9xnjEXo2cJ8L4pvDbHA+k/j7rqbY4o3h5EeMy93ClVUwoeJ2y/JWax/V1DWTyYMhq+9dXlcIUYQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1322,16 +1330,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-hVhpXIG5CXSqeLo7+d5VwN8b9X0BM8yMZCEIxVAu5050GlcHC3CeJVpy+2DEBkbvR9tzc2HfPGMpWyQpgnimhQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-beta.3.tgz",
+      "integrity": "sha512-eBNUkQdIDE2fWUXdIeRpN9OMxwfxU2WJFMRHst204Doanh8iJVp3Mz/+z9agHJ6Pkqth2XTXA0EDd1QiI37t+g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1339,15 +1347,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-zF2tPojJBGmQ/GuX+QJ0BhBWmnC+ET8Zah9utKpYWFFjqG/Wl6YzWpyrEflXpfGFzDFgoo+R+/3QvzScbPssqg==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-beta.3.tgz",
+      "integrity": "sha512-wKMdk5nplkT2PA1sRFZ2WOLmb7xi9++T6UnCeivmV+sy5NtUPpwkJLUWWIlZdZLyiGKmhZQ1gVvhsbyWRoAVPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1355,16 +1363,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-/7o+/Z2LelLcOdDSeY8O467Tjmr4yp0c8T4l13+zoQlaJFCzoeJqUUzP/dyqLPxqSeSMOez7uXnYpii6F8uYcA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-beta.3.tgz",
+      "integrity": "sha512-XltfOZNTjrBvrWx1hPU6pHn7lHKKY9jXmiQzojX/jhMjZ6Kp6TLGjMMU3SmEUPU6sTaXKUeO5UUTxe2v6VmqMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.3",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-json-pointer": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1372,15 +1380,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-workflows-1": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-tem8H3DHvQNxUqbiLmepccjAyFffS41Z90ibugsw17xzCNIIr6kDwlhiSSGkl52C+IBqoUlE6kdV0afPr2WuUA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-1.0.0-beta.3.tgz",
+      "integrity": "sha512-+7i8CZAC+TypSYuxTtwXH2qIyQC1ATn8r+1pW4NWCs4F2Yr4K2gGG4ZmOE6ckNa+Q53yyx+Spt7xhLfZDJZp/w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -1388,243 +1396,243 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-8yuL2w3G4zdBxyITLHKSFRwpgl8Rp4/bCR2GTznYKr5wYuN9RVSKAp2sGtuWHnynnpspodswu3AI1BVCLKBj1A==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-beta.3.tgz",
+      "integrity": "sha512-IpnxjLDVdRaY+ewNW8zbiMzYu5eKifpioFPGDlHc2MoTW6zqo5UKViZKL4MbsncySWBj7+URvTIFYjip3TvkKg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-I+/tRdC6CK0GfjZgOaTfpjtehkFW7i1A1ixFOPtrwKA8v3oZ2eUW7dIjDMMC0yTt67j7enHlGTw6o2rZZGnjpA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Pvj+4OMIzKMx77Ulbp/CdWGAQhor88q5BJlY3cuSNd2Oth+mfe6r7NUXWVSpG6H9+9Y6YJdnGOzQ1PHWJPOlqA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-FX4buMibcnz0rsQKMBUrZM8cS1/s0pi3TV9HAsKPQY1mKssyeUEE/nlp6DBbYM6kNCEdq2ALvnPtZVwEJpxS3A==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Z8xIy3pirwAapLgZ18BqRVua5rh0NsvQNpx+5Bi5yJD+SD6Syk5OqsgFkqN7T/LmyqpivQiYRgItUBaHXuDnxg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-JsPYRsaKCecY8UN2AHuHm6X0WgWfys6ypH8UPYic1n3XUfNPkTSOaUY87Vi04wJmy8pQ1F0wHeESY//Zb37aIA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Xl9MU1+24ZTDuGzy/mKVPlnMSvgA/lS+AoqwMzxLMuiIsTmnQX3gEdiM+pXmK7rg1KV/k0aLwDLKt3e00CPiXQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-CTSgLG33GgC3POxLBCzlXyBBUz+EFGe62VICH012RIYDXHDmcr4dPmfHyj85LVJxLh7regQ+SGL4NwqQSxTY3A==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-beta.3.tgz",
+      "integrity": "sha512-28zQdF8oeaUmNxZNU0De4JUY9jvxiaN+QCJ1GZN9aQ6NQ/eOAuGg+HRuL8+RrSe4STacdi1FCX46jHcMGQeqfg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.3",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.20.4",
-        "tree-sitter-json": "=0.20.2",
-        "web-tree-sitter": "=0.20.3"
+        "tree-sitter": "=0.21.1",
+        "tree-sitter-json": "=0.24.8",
+        "web-tree-sitter": "=0.24.3"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-YtPu2BansaTpW6MrIRJgZpa9V+MLl/DFqC2tHbGSO+u73PdWndONRgqzAAc5pBWR+u1RNgULrCK6sX7uPiFLVg==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-beta.3.tgz",
+      "integrity": "sha512-ufiQMl89sTGf09qlh/QvFLEUs9FH9ZZV4mjz1xIB127rnNbWg/sSGr0WIcJGKoLrioI9orb+7aqIhmSDw/plmw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-zzZdK+xhj+sVh4z3vZrxdBrDitraD1szJPc3sUC0pukuCz3P7R/u+//6+GLE9UVjUakdbQI2cyKyUOIZX51+/g==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-beta.3.tgz",
+      "integrity": "sha512-yINlDTIZCywuKRsBeJJDmQLV4+r9FaWDezb4omw6xFQnQZQV1tHgIb549OsV6lT70TabLj+HoMYNLQ9/Bm59Yw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-i7HaRnU2kDtvDqM5Yv1sbYZghCeRhiVQEyaIIp59Zhc5SwLS3dSoD/kh0TeuKpaY5Lg0ISIM3SLRDcdaYUsGww==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-beta.3.tgz",
+      "integrity": "sha512-kBZsyNHtp6w41g9N5c+PF4FqoE8vosxgYJEfhQeQs4qXK7T7d8sfjXwcnWRjqlOM4X8dt5R359h58AfwyEF20w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-QbqCTAvthqhZmFZKf9HBYnVt4kV7konYnauylVFIaE5KAzmZkcb30FtkAwmZfnyW3AURMzZcLfOgJRGHOjYSqA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-beta.3.tgz",
+      "integrity": "sha512-K/FRLCuB0UD9Nq/CNqfjkSVfQfzcpA7lJCg6QueZKd0dQJ54dyHFU9AroshutXHTmEjBleoL7V1K3PNh10HiYQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-ajVOqs8lNta7uXkFtU5k1zDJTjwV6Ki3uS+JwBvjuMHsF/i/WIZOmgI4g1Z3yQ1c0QI4dHJskq4WDyp2qW64aw==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-beta.3.tgz",
+      "integrity": "sha512-EUdpzJnqZqCu2keEyOxlCED/u0oaA05c6dO48XzbdyENONY/etoN5wrEoqxqxOz+1cC+FZWj/cnmsXdFfbJlEg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-ljYmbBFWjIcfN+MJr7JFh6NA/fgyu5gXDI6KUrg/sbWTKdUYP4iNLJPw8VLPBXHnExevjZCt1Ni74mmL4ZfyBg==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-beta.3.tgz",
+      "integrity": "sha512-2Q9vmrgTQ4cA5WALGyTLp8tF984R9C7QmDOjGf/ngrTIQLyyrQZ0ZDaXL7RHTmT6K9Lg6axMpKquBNiO+Aff6g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-vd0H5IYX96AIhOLcU9SJnXDD6OV61i00JDDfJcFnf1K2NCB0D0Otk2V2z9LXqe51s3pZ7d/Dz0biDjYMsMKVww==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-1.0.0-beta.3.tgz",
+      "integrity": "sha512-OsKz09YcfQfTbiNZueTLHBrn7umnMjtuN0ZzuNiBs5txaLS196grpzyTiG+4UJ1zIWvjvZmLZEbQqbKZ9qTw8A==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-lH0AiPetMLRDy38gcB6TmQnaKv6p1ePimnT4xqcVSHEnc/FsjMbyOE3x6DUENau2eeWFduAhofE9zvliW6iJaQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-1.0.0-beta.3.tgz",
+      "integrity": "sha512-IifK3T6UtqBkIoHOQe6QRGpFU9LFqmJ5T1JzbWnVX+gazoVE+N9ZkFWQfb9pKCaCfAwPVp+vai6bQ2eUsGh4CA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-beta.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-mW/W/Q8w4RCw41Y9vggPbsFg+gj0FxKdecVYzZ8TmgyM9oVN6/KZFegUYKlg1HDRAfjceKehE06aLLS5GXEJCA==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-beta.3.tgz",
+      "integrity": "sha512-sSGxnMTNNTqhJBeUOge4Q/5l/7170maoxyrK6J57kRxqkchSAqam73VIBpKa8c/sJ7zhdZI7CZ9aTJe/q7vc7w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
-        "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-ast": "^1.0.0-beta.3",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
+        "@swagger-api/apidom-error": "^1.0.0-beta.3",
+        "@tree-sitter-grammars/tree-sitter-yaml": "=0.6.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
-        "tree-sitter": "=0.20.4",
-        "tree-sitter-yaml": "=0.5.0",
-        "web-tree-sitter": "=0.20.3"
+        "tree-sitter": "=0.21.1",
+        "web-tree-sitter": "=0.24.3"
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-alpha.10.tgz",
-      "integrity": "sha512-aFG6EHC1NOa0IhawTiE8A8TffzmW0PSO5d+lpzvcJ0w7KbrYG6SFQF2L6lZppqGaIGWbmV0Mq3LDU9mgSVEqqQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-beta.3.tgz",
+      "integrity": "sha512-MkSW/uKA+iCUeQ5HqICGxXPZI1y5vbXnOZLT+22+ZvaO3+5j7tD2aS9mAF+140VaaE5AkpZE28XC9TaYyjEwDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+        "@swagger-api/apidom-core": "^1.0.0-beta.3",
         "@types/ramda": "~0.30.0",
         "axios": "^1.7.4",
         "minimatch": "^7.4.3",
@@ -1633,27 +1641,27 @@
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-error": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-workflows-json-1": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-alpha.1",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1"
+        "@swagger-api/apidom-error": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-json-pointer": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-workflows-1": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-workflows-json-1": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3 <1.0.0-rc.0"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
@@ -1693,6 +1701,26 @@
       "resolved": "https://registry.npmjs.org/@terraformer/common/-/common-2.1.2.tgz",
       "integrity": "sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ=="
     },
+    "node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.6.1.tgz",
+      "integrity": "sha512-FqgUNdtMuPpk5D/9YQvCxTK4tzlUEVq/yNewdcxJbMv0KVt/yDfuuUn5ZvxphftKyOco+1e/6/oNHCKVQ5A83Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1711,16 +1739,6 @@
       "integrity": "sha512-pTHyNlaMD/oKJmS+ZZUyFUcsZeBZpC0lmGquw98CqRVNgAdJZJeD7GoeLiT6Xbx5rU9VCjSt0RwEvDgzh4obFw==",
       "dependencies": {
         "@types/unist": "^2"
-      }
-    },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
       }
     },
     "node_modules/@types/mapbox__point-geometry": {
@@ -1755,12 +1773,6 @@
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
       "peer": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "license": "MIT"
-    },
     "node_modules/@types/ramda": {
       "version": "0.30.2",
       "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
@@ -1768,16 +1780,6 @@
       "license": "MIT",
       "dependencies": {
         "types-ramda": "^0.30.1"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
-      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -2064,12 +2066,6 @@
         }
       }
     },
-    "node_modules/@yarnpkg/lockfile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -2169,6 +2165,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2289,6 +2286,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -2387,18 +2385,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/blob-util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -2421,6 +2407,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2474,7 +2461,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2591,6 +2578,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -2639,6 +2627,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2654,6 +2643,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2767,13 +2757,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/chroma-js": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
@@ -2784,6 +2767,7 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2864,6 +2848,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2874,7 +2859,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2934,7 +2920,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -2975,9 +2962,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.38.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
-      "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.39.0.tgz",
+      "integrity": "sha512-7fEcWwKI4rJinnK+wLTezeg2smbFFdSBP6E2kQZNbnzM2s1rpKQ6aaRteZSSg7FLU3P0HGGVo/gbpfanU36urg==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -2992,9 +2979,10 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3127,22 +3115,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -3177,6 +3149,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -3206,16 +3179,6 @@
       "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==",
       "license": "MIT"
     },
-    "node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3229,9 +3192,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
-      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
       "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/dotenv": {
@@ -3292,7 +3255,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -3679,16 +3642,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3903,15 +3856,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/find-yarn-workspace-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
-      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "micromatch": "^4.0.2"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -3988,17 +3932,11 @@
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "dev": true
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -4036,7 +3974,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4055,6 +3994,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4078,6 +4018,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -4149,13 +4090,6 @@
         "giget": "dist/cli.mjs"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/gl-matrix": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
@@ -4166,6 +4100,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4291,6 +4226,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -4301,7 +4237,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4321,6 +4258,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4329,6 +4267,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.2"
       },
@@ -4340,6 +4279,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4351,6 +4291,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4368,6 +4309,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4406,15 +4348,6 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/hookable": {
@@ -4516,6 +4449,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4596,21 +4530,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extendable": {
@@ -4723,24 +4642,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4840,24 +4741,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.5",
-        "isarray": "^2.0.5",
-        "jsonify": "^0.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4892,20 +4775,12 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsprim": {
@@ -4945,15 +4820,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/klaw-sync": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
-      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/klona": {
@@ -5333,19 +5199,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minim": {
       "version": "0.23.8",
       "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
@@ -5362,6 +5215,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5423,13 +5277,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/mlly": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
@@ -5462,13 +5309,6 @@
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "peer": true
     },
-    "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -5486,13 +5326,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5508,24 +5341,21 @@
         "node": ">= 10"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.71.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
-      "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -5568,6 +5398,18 @@
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
       "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -5779,15 +5621,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ohash": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
@@ -5798,6 +5631,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5812,22 +5646,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5872,15 +5690,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ospath": {
@@ -5971,61 +5780,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/patch-package": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
-      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
-      "license": "MIT",
-      "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.7.0",
-        "cross-spawn": "^7.0.3",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^9.0.0",
-        "json-stable-stringify": "^1.0.2",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.6",
-        "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^7.5.3",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "patch-package": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">5"
-      }
-    },
-    "node_modules/patch-package/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/patch-package/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6038,6 +5792,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6324,33 +6079,6 @@
       "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
       "peer": true
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6475,7 +6203,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6581,39 +6309,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rc9": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
@@ -6628,6 +6323,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -6707,51 +6403,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-redux": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/use-sync-external-store": "^0.0.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "react-is": "^18.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.8 || ^17.0 || ^18.0",
-        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react": "^16.8 || ^17.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0 || ^18.0",
-        "react-native": ">=0.59",
-        "redux": "^4 || ^5.0.0-beta.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-redux/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
     "node_modules/react-syntax-highlighter": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
@@ -6767,21 +6418,6 @@
         "react": ">= 0.14.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6795,13 +6431,10 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/redux-immutable": {
       "version": "4.0.0",
@@ -6884,9 +6517,9 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -7098,6 +6731,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
       "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -7195,62 +6829,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/slash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/slice-ansi": {
       "version": "3.0.0",
@@ -7492,16 +7070,6 @@
         "duplexer": "~0.1.1"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -7592,17 +7160,18 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.29.4.tgz",
-      "integrity": "sha512-Me8tdPyRAQbnwNBCZ0BpG0vyci9e+FW6YV3+c6/x8SwPmLpslpFNXoT4PtVApf1CVSvV7Sc7Bfb4DPgpEqBdHw==",
+      "version": "3.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.32.2.tgz",
+      "integrity": "sha512-efuUECHpI64BAsh+UuVkZsabLu0JDpHFo2tGp2Gc2J9W+7cY2YgVXQobY992ZNQnYU+gFiqyWLnoqtpqnzeB1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
-        "@swagger-api/apidom-core": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-        "@swagger-api/apidom-error": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-        "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-        "@swagger-api/apidom-reference": ">=1.0.0-alpha.9 <1.0.0-beta.0",
+        "@scarf/scarf": "=1.4.0",
+        "@swagger-api/apidom-core": ">=1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-error": ">=1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-json-pointer": ">=1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-beta.3 <1.0.0-rc.0",
+        "@swagger-api/apidom-reference": ">=1.0.0-beta.3 <1.0.0-rc.0",
         "cookie": "~0.7.2",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
@@ -7617,44 +7186,43 @@
       }
     },
     "node_modules/swagger-ui": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.9.0.tgz",
-      "integrity": "sha512-x+FB8V7RtFaXdwWx0dNbI1nqaDCQI1yhJ5Db0obh8Fu3zr832VEXLbMi9hixQCRWv7FcbWy0baQA0x/4oHhqyw==",
-      "hasInstallScript": true,
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.18.2.tgz",
+      "integrity": "sha512-zu28qHMVaXrL2T02xEnItoKQcS6tikJs6IJpzjoXexqJCqhwYAXOOypnXYMPkVfq9Ige67oPuUQvEGdeid0/Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.23.1",
-        "@braintree/sanitize-url": "=6.0.4",
+        "@babel/runtime-corejs3": "^7.24.7",
+        "@braintree/sanitize-url": "=7.0.4",
+        "@scarf/scarf": "=1.4.0",
         "base64-js": "^1.5.1",
-        "classnames": "^2.3.1",
+        "classnames": "^2.5.1",
         "css.escape": "1.5.1",
         "deep-extend": "0.6.0",
-        "dompurify": "=3.0.6",
+        "dompurify": "=3.1.6",
         "ieee754": "^1.2.1",
         "immutable": "^3.x.x",
         "js-file-download": "^0.4.12",
         "js-yaml": "=4.1.0",
         "lodash": "^4.17.21",
-        "patch-package": "^8.0.0",
         "prop-types": "^15.8.1",
         "randexp": "^0.5.3",
         "randombytes": "^2.1.0",
-        "react": "=17.0.2",
+        "react": ">=16.8.0 <19",
         "react-copy-to-clipboard": "5.1.0",
         "react-debounce-input": "=3.3.0",
-        "react-dom": "=17.0.2",
+        "react-dom": ">=16.8.0 <19",
         "react-immutable-proptypes": "2.2.0",
         "react-immutable-pure-component": "^2.2.0",
         "react-inspector": "^6.0.1",
-        "react-redux": "^8.1.2",
+        "react-redux": "^9.1.2",
         "react-syntax-highlighter": "^15.5.0",
-        "redux": "^4.1.2",
+        "redux": "^5.0.1",
         "redux-immutable": "^4.0.0",
         "remarkable": "^2.0.1",
-        "reselect": "^4.1.8",
+        "reselect": "^5.1.1",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.22.3",
+        "swagger-client": "^3.31.0",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -7667,6 +7235,41 @@
       "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/swagger-ui/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/swagger-ui/node_modules/react-redux": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25",
+        "react": "^18.0",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/synckit": {
@@ -7700,36 +7303,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/chownr": {
@@ -7827,37 +7400,35 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.4.tgz",
-      "integrity": "sha512-rjfR5dc4knG3jnJNN/giJ9WOoN1zL/kZyrS0ILh+eqq8RNcIbiXA63JsMEgluug0aNvfQvK4BfCErN1vIzvKog==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "nan": "^2.17.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
       }
     },
     "node_modules/tree-sitter-json": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.20.2.tgz",
-      "integrity": "sha512-eUxrowp4F1QEGk/i7Sa+Xl8Crlfp7J0AXxX1QdJEQKQYMWhgMbCIgyQvpO3Q0P9oyTrNQxRLlRipDS44a8EtRw==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
+      "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "nan": "^2.18.0"
-      }
-    },
-    "node_modules/tree-sitter-yaml": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-yaml/-/tree-sitter-yaml-0.5.0.tgz",
-      "integrity": "sha512-POJ4ZNXXSWIG/W4Rjuyg36MkUD4d769YRUGKRqN+sVaj/VCo6Dh6Pkssn1Rtewd5kybx+jT1BWMyWN0CijXnMA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.14.0"
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-mixer": {
@@ -7881,7 +7452,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -8054,6 +7625,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -8174,7 +7746,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -8411,9 +7983,9 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.3.tgz",
-      "integrity": "sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.3.tgz",
+      "integrity": "sha512-uR9YNewr1S2EzPKE+y39nAwaTyobBaZRG/IsfkB/OT4v0lXtNj5WjtHKgn2h7eOYUWIZh5rK9Px7tI6S9CRKdA==",
       "license": "MIT",
       "optional": true
     },
@@ -8457,7 +8029,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/xml": {
       "version": "1.0.1",
@@ -8494,18 +8067,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "marked": "^14.1.3",
     "pinia": "^2.1.6",
     "pinia-plugin-persistedstate": "^4.1.3",
-    "swagger-ui": "5.9.0",
+    "swagger-ui": "^5.18.2",
     "vite-plugin-vuetify": "^1.0.2",
     "vue": "^3.3.4",
     "vue-chartjs": "^5.3.0",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@mdi/font": "^7.3.67",
-    "@mdi/js": "^7.3.67",
+    "@mdi/js": "^7.4.47",
     "@rushstack/eslint-patch": "^1.3.3",
     "@vitejs/plugin-vue": "^4.3.4",
     "@vue/eslint-config-prettier": "^8.0.0",

--- a/frontend/src/components/StaticMetadata.vue
+++ b/frontend/src/components/StaticMetadata.vue
@@ -11,7 +11,7 @@
         <div v-for="metadataObject in defaultSwordMetadata()" :key="metadataObject.id">
           <v-divider />
           <div>
-            <strong>{{ metadataObject.short_definition }}:</strong> {{ metadataObject.value }}
+            <strong>{{ metadataObject.displayKey }}:</strong> {{ metadataObject.value }}
           </div>
         </div>
         <template v-if="extended">
@@ -21,7 +21,7 @@
           >
             <v-divider />
             <div>
-              <strong>{{ extendedMetadataObject.short_definition }}:</strong>
+              <strong>{{ extendedMetadataObject.displayKey }}:</strong>
               {{ extendedMetadataObject.value }}
             </div>
           </div>

--- a/frontend/src/components/StaticMetadata.vue
+++ b/frontend/src/components/StaticMetadata.vue
@@ -8,21 +8,42 @@
                 </v-card-subtitle> -->
       </v-card-item>
       <v-card-text>
+        <!-- Default Metadata -->
         <div v-for="metadataObject in defaultSwordMetadata()" :key="metadataObject.id">
           <v-divider />
-          <div>
-            <strong>{{ metadataObject.displayKey }}:</strong> {{ metadataObject.value }}
+          <div style="display: flex; align-items: center; justify-content: space-between;">
+            <div>
+              <strong>{{ metadataObject.displayKey }}:</strong> {{ metadataObject.value }}
+            </div>
+            <!-- Tooltip Icon -->
+            <v-tooltip location="top" max-width="200px" style="white-space: normal;">
+              <template #activator="{ props }">
+                <v-icon v-bind="props" :icon="mdiInformationOutline" color="primary" style="cursor: pointer; margin-left: 10px;">
+                </v-icon>
+              </template>
+              <div>{{ metadataObject.definition }}</div>
+            </v-tooltip> 
           </div>
         </div>
+        <!-- Extended Metadata -->
         <template v-if="extended">
           <div
             v-for="extendedMetadataObject in extendedMetadata()"
             :key="extendedMetadataObject.id"
           >
             <v-divider />
-            <div>
-              <strong>{{ extendedMetadataObject.displayKey }}:</strong>
-              {{ extendedMetadataObject.value }}
+            <div style="display: flex; align-items: center; justify-content: space-between;">
+              <div>
+                <strong>{{ extendedMetadataObject.displayKey }}:</strong> {{ extendedMetadataObject.value }}
+              </div>
+                <!-- Tooltip Icon -->
+              <v-tooltip location="top" max-width="200px" style="white-space: normal;">
+                <template #activator="{ props }">
+                  <v-icon v-bind="props" :icon="mdiInformationOutline" color="primary" style="cursor: pointer; margin-left: 10px;">
+                  </v-icon>
+                </template>
+                <span>{{ extendedMetadataObject.definition }}</span>
+              </v-tooltip>
             </div>
           </div>
         </template>
@@ -41,7 +62,7 @@
 import { ref,  } from 'vue'
 import { useFeaturesStore } from '@/stores/features'
 import { useHydrologicStore } from '@/stores/hydrologic'
-import { mdiSword } from '@mdi/js'
+import { mdiSword, mdiInformationOutline } from '@mdi/js'
 
 const props = defineProps({
   reachId: { type: Number, default: 0 },

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -292,10 +292,10 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'Maximum flow accumulation value for a node or reach. Flow accumulation values are extracted from the MERIT Hydro dataset (Yamazaki et al., 2019)',
-      swotviz_alias: 'Flow Accumulation',
+      swotviz_alias: 'Maximum Flow Accumulation',
         units: 'square kilometers',
       plottable: true,
-      plot_definition: 'Maximum Flow Accumulation',
+      plot_definition: 'Flow Accumulation',
       significant_figures: 0 //TODO: Check this
     },
     {
@@ -328,9 +328,17 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'Type of obstruction for each node or reach based on the Globale Obstruction Database (GROD, Whittemore et al., 2020) and HydroFALLS data (http://wp.geog.mcgill.ca/hydrolab/hydrofalls). Obstr_type values: 0 - No Dam, 1 - Dam, 2 - Channel Dam, 3 - Lock, 4 - Low Permeable Dam, 5 - Waterfall',
-      swotviz_alias: 'Obstruction Type based on Global River Obstruction Database (GROD)',
+      swotviz_alias: 'Obstruction Type',
       units: '',
-      plottable: false
+      plottable: false,
+      mapping: {
+        0: 'No Dam',
+        1: 'Dam',
+        2: 'Channel Dam',
+        3: 'Lock',
+        4: 'Low Permeable Dam',
+        5: 'Waterfall'
+      }
     },
     {
       abbreviation: 'grod_id',
@@ -338,10 +346,13 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: false,
       short_definition: 'The unique GROD ID for each node or reach with obstr_type values 1-4',
-      swotviz_alias: 'GROD ID',
+      swotviz_alias: 'Global River Obstruction Database (GROD) ID',
       units: '',
       plottable: false,
-      significant_figures: 0 //TODO: Check this
+      significant_figures: 0, //TODO: Check this
+      mapping: {
+        0: '-',
+      }
     },
     {
       abbreviation: 'hfalls_id',
@@ -352,7 +363,10 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       swotviz_alias: 'HydroFALLS ID',
       units: '',
       plottable: false,
-      significant_figures: 0 //TODO: Check this
+      significant_figures: 0, //TODO: Check this
+      mapping: {
+        0: '-',
+      }
     },
     {
       abbreviation: 'dist_out',
@@ -373,9 +387,17 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'Type identifier for a node or reach: 1=river, 2=lake off river, 3=lake on river, 4=dam or waterfall, 5=unreliable topology, 6=ghost reach/node',
-      swotviz_alias: 'Type',
+      swotviz_alias: 'Reach Type',
       units: '',
-      plottable: false
+      plottable: false,
+      mapping: {
+        1: 'River',
+        2: 'Lake Off River',
+        3: 'Lake On River',
+        4: 'Dam or Waterfall',
+        5: 'Unreliable Topology',
+        6: 'Ghost Reach'
+      }
     },
     {
       abbreviation: 'lakeflag',
@@ -385,9 +407,15 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'GRWL water body identifier for each reach:  0=river, 1=lake/reservoir, 2=tidally influenced river,  3=canal',
-      swotviz_alias: 'Lake Flag based on Global River Widths from Landsat (GRWL)',
+      swotviz_alias: 'Lake Flag',
       units: '',
-      plottable: false
+      plottable: false,
+      mapping: {
+        0: 'River',
+        1: 'Lake/Reservoir',
+        2: 'Tidally Influenced River',
+        3: 'Canal'
+      }
     },
     {
       abbreviation: 'slope',
@@ -517,13 +545,17 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
     for (const [abbreviation, val] of Object.entries(feature)) {
       const found = variableFromAbreviation(abbreviation, fileType, defaultOnly)
       if (found) {
-        const isNumber = !isNaN(parseFloat(val)) && isFinite(val)
-        const significantFigures = found.significant_figures       
-        const displayKey = found.swotviz_alias // Use alias 
-        found.value = isNumber
-        ? `${parseFloat(val).toFixed(significantFigures)} ${found.units}`
-        : `${val} ${found.units}`
-        
+        let displayValue;
+        const displayKey = found.swotviz_alias || found.short_definition // Use alias if available
+        if (found.mapping && found.mapping[val]) {
+            displayValue = found.mapping[val];
+        } else {
+            const isNumber = !isNaN(parseFloat(val)) && isFinite(val)
+            displayValue = isNumber
+              ? `${parseFloat(val).toFixed(found.significant_figures)} ${found.units}`
+              : `${val} ${found.units}`
+        }
+        found.value = displayValue;           
         descriptions.push({...found, displayKey})
       }
     }

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -549,6 +549,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
         const displayKey = found.swotviz_alias || found.short_definition // Use alias if available
         if (found.mapping && found.mapping[val]) {
             displayValue = found.mapping[val];
+        } else if (typeof val === 'string' && val.includes(' ')) {
+            displayValue = val.split(' ').join(', ');
         } else {
             const isNumber = !isNaN(parseFloat(val)) && isFinite(val)
             displayValue = isNumber

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -296,7 +296,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
         units: 'square kilometers',
       plottable: true,
       plot_definition: 'Flow Accumulation',
-      significant_figures: 0 //TODO: Check this
+      significant_figures: 0 
     },
     {
       abbreviation: 'n_chan_max',
@@ -307,7 +307,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       swotviz_alias: 'Maximum Channel Count',
       units: '',
       plottable: false,
-      significant_figures: 0 //TODO: Check this
+      significant_figures: 0 
     },
     {
       abbreviation: 'n_chan_mod',
@@ -318,7 +318,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       swotviz_alias: 'Mode Channel Count',
       units: '',
       plottable: false,
-      significant_figures: 0 //TODO: Check this
+      significant_figures: 0 
     },
     {
       abbreviation: 'obstr_type',
@@ -349,7 +349,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       swotviz_alias: 'Global River Obstruction Database (GROD) ID',
       units: '',
       plottable: false,
-      significant_figures: 0, //TODO: Check this
+      significant_figures: 0, 
       mapping: {
         0: '-',
       }
@@ -363,7 +363,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       swotviz_alias: 'HydroFALLS ID',
       units: '',
       plottable: false,
-      significant_figures: 0, //TODO: Check this
+      significant_figures: 0, 
       mapping: {
         0: '-',
       }
@@ -377,7 +377,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       swotviz_alias: 'Distance to Outlet',
       units: 'meters',
       plottable: false,
-      significant_figures: 2 //TODO: Check this
+      significant_figures: 2 
     },
     {
       abbreviation: 'type',

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -169,6 +169,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: true,
       short_definition: 'Longitude',
+      swotviz_alias: 'Longitude',
       units: 'decimal degrees',
       plottable: false,
       significant_figures: 4
@@ -179,6 +180,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: true,
       short_definition: 'Latitude',
+      swotviz_alias: 'Latitude',
       units: 'decimal degrees',
       plottable: false,
       significant_figures: 4
@@ -190,6 +192,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'node',
       default: true,
       short_definition: 'Node ID',
+      swotviz_alias: 'Node ID',
       units: '',
       plottable: false,
       significant_figures: 0
@@ -200,6 +203,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'node',
       default: false,
       short_definition: 'Node length measured along the GRWL centerline points',
+      swotviz_alias: 'Node Length',
       units: 'meters',
       plottable: false,
       significant_figures: 2
@@ -213,6 +217,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition: 'Reach ID', // Differs from the abbreviation in the SWORD documentation
       // https://zenodo.org/records/3898570
       // abbreviation: 'reach_length',
+      swotviz_alias: 'Reach ID',
       units: '',
       plottable: false,
       significant_figures: 0
@@ -223,6 +228,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'reach',
       default: true,
       short_definition: 'Reach Length',
+      swotviz_alias: 'Reach Length',
       units: 'meters',
       plottable: false,
       significant_figures: 2
@@ -234,6 +240,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: true,
       short_definition: 'Average water surface elevation (WSE)',
+      swotviz_alias: 'Average Water Surface Elevation (WSE)',
       units: 'meters',
       plottable: true,
       plot_definition: 'Water Surface Elevation',
@@ -247,6 +254,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'WSE variance along the GRWL centerline points used to calculate the average WSE for each node or reach',
+        swotviz_alias: 'WSE Variance',
       units: 'square meters',
       plottable: false,
       significant_figures: 2
@@ -257,6 +265,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: true,
       short_definition: 'Average width',
+      swotviz_alias: 'Average Width',
       units: 'meters',
       plottable: true,
       plot_definition: 'Width',
@@ -270,7 +279,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'Width variance along the GRWL centerline points used to calculate the average width for each node or reach',
-      units: 'square meters',
+      swotviz_alias: 'Width Variance',
+        units: 'square meters',
       plottable: false,
       significant_figures: 2
     },
@@ -282,9 +292,10 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'Maximum flow accumulation value for a node or reach. Flow accumulation values are extracted from the MERIT Hydro dataset (Yamazaki et al., 2019)',
-      units: 'square kilometers',
+      swotviz_alias: 'Flow Accumulation',
+        units: 'square kilometers',
       plottable: true,
-      plot_definition: 'Flow Accumulation',
+      plot_definition: 'Maximum Flow Accumulation',
       significant_figures: 0 //TODO: Check this
     },
     {
@@ -293,6 +304,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: false,
       short_definition: 'Maximum number of channels for each node or reach',
+      swotviz_alias: 'Maximum Channel Count',
       units: '',
       plottable: false,
       significant_figures: 0 //TODO: Check this
@@ -303,6 +315,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: false,
       short_definition: 'Mode of the number of channels for each node or reach',
+      swotviz_alias: 'Mode Channel Count',
       units: '',
       plottable: false,
       significant_figures: 0 //TODO: Check this
@@ -315,6 +328,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'Type of obstruction for each node or reach based on the Globale Obstruction Database (GROD, Whittemore et al., 2020) and HydroFALLS data (http://wp.geog.mcgill.ca/hydrolab/hydrofalls). Obstr_type values: 0 - No Dam, 1 - Dam, 2 - Channel Dam, 3 - Lock, 4 - Low Permeable Dam, 5 - Waterfall',
+      swotviz_alias: 'Obstruction Type based on Global River Obstruction Database (GROD)',
       units: '',
       plottable: false
     },
@@ -324,6 +338,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: false,
       short_definition: 'The unique GROD ID for each node or reach with obstr_type values 1-4',
+      swotviz_alias: 'GROD ID',
       units: '',
       plottable: false,
       significant_figures: 0 //TODO: Check this
@@ -334,6 +349,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: false,
       short_definition: 'The unique HydroFALLS ID for each node or reach with obstr_type value 5',
+      swotviz_alias: 'HydroFALLS ID',
       units: '',
       plottable: false,
       significant_figures: 0 //TODO: Check this
@@ -344,6 +360,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'all',
       default: false,
       short_definition: 'Distance from the river outlet for each node or reach',
+      swotviz_alias: 'Distance to Outlet',
       units: 'meters',
       plottable: false,
       significant_figures: 2 //TODO: Check this
@@ -356,6 +373,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'Type identifier for a node or reach: 1=river, 2=lake off river, 3=lake on river, 4=dam or waterfall, 5=unreliable topology, 6=ghost reach/node',
+      swotviz_alias: 'Type',
       units: '',
       plottable: false
     },
@@ -367,6 +385,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'GRWL water body identifier for each reach:  0=river, 1=lake/reservoir, 2=tidally influenced river,  3=canal',
+      swotviz_alias: 'Lake Flag based on Global River Widths from Landsat (GRWL)',
       units: '',
       plottable: false
     },
@@ -377,6 +396,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'reach',
       default: true,
       short_definition: 'Average reach slope',
+      swotviz_alias: 'Average Reach Slope',
       units: 'meters/kilometer',
       plottable: true,
       plot_definition: 'Slope',
@@ -388,6 +408,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'reach',
       default: true,
       short_definition: 'Number of nodes associated with the reach',
+      swotviz_alias: 'Node Count',
       units: '',
       plottable: false,
       significant_figures: 0 
@@ -398,6 +419,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'reach',
       default: false,
       short_definition: 'Number of upstream reaches for each reach',
+      swotviz_alias: 'Upstream Reach Count',
       units: '',
       plottable: false,
       significant_figures: 0 
@@ -408,6 +430,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'reach',
       default: false,
       short_definition: 'Number of downstream reaches for each reach',
+      swotviz_alias: 'Downstream Reach Count',
       units: '',
       plottable: false,
       significant_figures: 0 
@@ -418,6 +441,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'reach',
       default: true,
       short_definition: 'Upstream reach ID',
+      swotviz_alias: 'Upstream Reach ID',
       units: '',
       plottable: false,
       significant_figures: 0 
@@ -428,6 +452,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       fileType: 'reach',
       default: true,
       short_definition: 'Downstram reach ID',
+      swotviz_alias: 'Downstram Reach ID',
       units: '',
       plottable: false,
       significant_figures: 0 
@@ -440,6 +465,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'The maximum number of SWOT passes to intersect each reach during the 21 day orbit cycle',
+      swotviz_alias: 'SWOT Pass Count',
       units: '',
       plottable: false,
       significant_figures: 0 
@@ -452,6 +478,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition:
         'A list of the SWOT orbit tracks that intersect each reach during the 21 day orbit cycle',
+      swotviz_alias: 'SWOT Orbit Tracks',
       units: '',
       plottable: false,
       significant_figures: 0 
@@ -491,11 +518,13 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       const found = variableFromAbreviation(abbreviation, fileType, defaultOnly)
       if (found) {
         const isNumber = !isNaN(parseFloat(val)) && isFinite(val)
-        const significantFigures = found.significant_figures 
+        const significantFigures = found.significant_figures       
+        const displayKey = found.swotviz_alias // Use alias 
         found.value = isNumber
         ? `${parseFloat(val).toFixed(significantFigures)} ${found.units}`
         : `${val} ${found.units}`
-        descriptions.push(found)
+        
+        descriptions.push({...found, displayKey})
       }
     }
     return descriptions

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -25,7 +25,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       always: false,
       selectable: true,
       fileType: 'all',
-      plottable: true
+      plottable: true,
+      
     },
     {
       abbreviation: 'slope',
@@ -169,7 +170,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: true,
       short_definition: 'Longitude',
       units: 'decimal degrees',
-      plottable: false
+      plottable: false,
+      significant_figures: 4
     },
     {
       abbreviation: 'y',
@@ -178,7 +180,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: true,
       short_definition: 'Latitude',
       units: 'decimal degrees',
-      plottable: false
+      plottable: false,
+      significant_figures: 4
     },
     {
       abbreviation: 'node_id',
@@ -188,7 +191,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: true,
       short_definition: 'Node ID',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0
     },
     {
       abbreviation: 'node_length',
@@ -197,7 +201,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'Node length measured along the GRWL centerline points',
       units: 'meters',
-      plottable: false
+      plottable: false,
+      significant_figures: 2
     },
     {
       abbreviation: 'reach_id',
@@ -209,7 +214,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       // https://zenodo.org/records/3898570
       // abbreviation: 'reach_length',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0
     },
     {
       abbreviation: 'reach_len',
@@ -218,7 +224,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: true,
       short_definition: 'Reach Length',
       units: 'meters',
-      plottable: false
+      plottable: false,
+      significant_figures: 2
     },
     {
       abbreviation: 'wse',
@@ -229,7 +236,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition: 'Average water surface elevation (WSE)',
       units: 'meters',
       plottable: true,
-      plot_definition: 'Water Surface Elevation'
+      plot_definition: 'Water Surface Elevation',
+      significant_figures: 2
     },
     {
       abbreviation: 'wse_var',
@@ -240,7 +248,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition:
         'WSE variance along the GRWL centerline points used to calculate the average WSE for each node or reach',
       units: 'square meters',
-      plottable: false
+      plottable: false,
+      significant_figures: 2
     },
     {
       abbreviation: 'width',
@@ -250,7 +259,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition: 'Average width',
       units: 'meters',
       plottable: true,
-      plot_definition: 'Width'
+      plot_definition: 'Width',
+      significant_figures: 2
     },
     {
       abbreviation: 'width_var',
@@ -261,7 +271,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition:
         'Width variance along the GRWL centerline points used to calculate the average width for each node or reach',
       units: 'square meters',
-      plottable: false
+      plottable: false,
+      significant_figures: 2
     },
     {
       abbreviation: 'facc',
@@ -273,7 +284,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
         'Maximum flow accumulation value for a node or reach. Flow accumulation values are extracted from the MERIT Hydro dataset (Yamazaki et al., 2019)',
       units: 'square kilometers',
       plottable: true,
-      plot_definition: 'Flow Accumulation'
+      plot_definition: 'Flow Accumulation',
+      significant_figures: 0 //TODO: Check this
     },
     {
       abbreviation: 'n_chan_max',
@@ -282,7 +294,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'Maximum number of channels for each node or reach',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 //TODO: Check this
     },
     {
       abbreviation: 'n_chan_mod',
@@ -291,7 +304,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'Mode of the number of channels for each node or reach',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 //TODO: Check this
     },
     {
       abbreviation: 'obstr_type',
@@ -311,7 +325,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'The unique GROD ID for each node or reach with obstr_type values 1-4',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 //TODO: Check this
     },
     {
       abbreviation: 'hfalls_id',
@@ -320,7 +335,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'The unique HydroFALLS ID for each node or reach with obstr_type value 5',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 //TODO: Check this
     },
     {
       abbreviation: 'dist_out',
@@ -329,7 +345,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'Distance from the river outlet for each node or reach',
       units: 'meters',
-      plottable: false
+      plottable: false,
+      significant_figures: 2 //TODO: Check this
     },
     {
       abbreviation: 'type',
@@ -362,7 +379,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition: 'Average reach slope',
       units: 'meters/kilometer',
       plottable: true,
-      plot_definition: 'Slope'
+      plot_definition: 'Slope',
+      significant_figures: 3
     },
     {
       abbreviation: 'n_nodes',
@@ -371,7 +389,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: true,
       short_definition: 'Number of nodes associated with the reach',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 
     },
     {
       abbreviation: 'n_rch_up',
@@ -380,7 +399,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'Number of upstream reaches for each reach',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 
     },
     {
       abbreviation: 'n_rch_down',
@@ -389,7 +409,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: false,
       short_definition: 'Number of downstream reaches for each reach',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 
     },
     {
       abbreviation: 'rch_id_up',
@@ -398,7 +419,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: true,
       short_definition: 'Upstream reach ID',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 
     },
     {
       abbreviation: 'rch_id_dn',
@@ -407,7 +429,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       default: true,
       short_definition: 'Downstram reach ID',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 
     },
     {
       abbreviation: 'swot_obs',
@@ -418,7 +441,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition:
         'The maximum number of SWOT passes to intersect each reach during the 21 day orbit cycle',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 
     },
     {
       abbreviation: 'swot_orbits',
@@ -429,7 +453,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       short_definition:
         'A list of the SWOT orbit tracks that intersect each reach during the 21 day orbit cycle',
       units: '',
-      plottable: false
+      plottable: false,
+      significant_figures: 0 
     }
   ])
 
@@ -465,7 +490,11 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
     for (const [abbreviation, val] of Object.entries(feature)) {
       const found = variableFromAbreviation(abbreviation, fileType, defaultOnly)
       if (found) {
-        found.value = `${val} ${found.units}`
+        const isNumber = !isNaN(parseFloat(val)) && isFinite(val)
+        const significantFigures = found.significant_figures 
+        found.value = isNumber
+        ? `${parseFloat(val).toFixed(significantFigures)} ${found.units || ''}`
+        : `${val} ${found.units || ''}`
         descriptions.push(found)
       }
     }

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -471,7 +471,7 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
       significant_figures: 0 
     },
     {
-      abbreviation: 'swot_orbits',
+      abbreviation: 'swot_orbit',
       definition:
         'A list of the SWOT orbit tracks that intersect each reach during the 21 day orbit cycle',
       fileType: 'reach',

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -493,8 +493,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
         const isNumber = !isNaN(parseFloat(val)) && isFinite(val)
         const significantFigures = found.significant_figures 
         found.value = isNumber
-        ? `${parseFloat(val).toFixed(significantFigures)} ${found.units || ''}`
-        : `${val} ${found.units || ''}`
+        ? `${parseFloat(val).toFixed(significantFigures)} ${found.units}`
+        : `${val} ${found.units}`
         descriptions.push(found)
       }
     }


### PR DESCRIPTION
List of changes:

- Reduced the significant figures by adding the `significant_figures` property to the `swotVariables` and `swordVariables` in `hydrologic.js` to make the number of significant figures configurable for each variable. 
- Updated the `getSwordDescriptions` function in the `hydrologic.js` to format numerical values to the desired number of significant figures.
- Added `swotviz_alias` property to the `swotVariables` and `swordVariables` in `hydrologic.js` to display a shorter key names for metadata. 
- Updated the `getSwordDescriptions` function in `hydrologic.js` to use the alias property.
- Updated the template in `StaticMetadata.vue` to display alias property instead of short_definition.
- Added a `mapping` property to the `swotVariables` and `swordVariables` in `hydrologic.js` to display the real names rather than code numbers (e.g., Reach Type = River instead of Reach Typle = 1).
- Updated the `getSwordDescriptions` function in `hydrologic.js` to use the mapping property.
- Added a small "info" icon (using mdi-information-outline from Material Design Icons) to the `StaticMetadata.vue` to show a full description next to each metadata variable.