### PR TITLE
Add a "Data Quality Legend" to the chart plot and added a "Reset Zoom" button to both chart and node plots

### DIFF
--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -46,10 +46,10 @@
                 <v-icon :icon="mdiCodeJson"></v-icon>
                 Download JSON
               </v-btn>
-              <v-btn @click="resetZoom()" color="input" class="ma-1">
+              <!-- <v-btn @click="resetZoom()" color="input" class="ma-1">
                 <v-icon :icon="mdiMagnifyMinusOutline"></v-icon>
                 Reset Zoom
-              </v-btn>
+              </v-btn> -->
             </v-expansion-panel-text>
           </v-expansion-panel>
           <v-expansion-panel

--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -156,8 +156,29 @@ const options = {
   parsing: getParsing,
   plugins: {
     legend: {
-      display: false,
-      position: 'bottom'
+      display: true,
+      position: 'top',
+      align : 'end',
+      labels: {
+        usePointStyle: true,
+        generateLabels: () => chartStore.generateDataQualityLegend(),
+        font: {
+          size: 12,
+        },
+        boxWidth: 20,
+        padding: 10,
+      },
+      title: {
+        display: true,
+        text: 'Data Quality',
+        font: {
+          size: 16,
+          weight: 'bold',
+        },
+        padding: {
+          top: 10,
+        },
+      },
     },
     title: {
       display: true,

--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -7,7 +7,20 @@
           :max-height="lgAndUp ? '100%' : '20vh'"
           max-width="100%"
           min-width="500px"
+          style="position: relative;"
         >
+        <!-- Add Reset Zoom Icon -->
+        <v-btn
+          class="zoom-button"
+          color="#f4f4f4"
+          outlined
+          @click="resetZoom()"
+          style="position: absolute; top: 110px; right: 10px; z-index: 10;"
+          >
+          <v-icon :icon="mdiMagnifyMinusOutline" class="me-2"></v-icon>
+          RESET ZOOM
+        </v-btn> 
+        <!-- Chart -->
           <Line :data="chartData" :options="options" ref="lineChart" />
         </v-sheet>
       </v-col>

--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -14,7 +14,7 @@
             color="input"
             size="small"
             @click="resetZoom()"
-            style="position: absolute; top: 110px; right: 10px; z-index: 10;"
+            style="position: absolute; top: 120px; right: 45px; z-index: 10;"
             :icon="mdiMagnifyMinusOutline"
           >
           </v-btn>

--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -7,16 +7,20 @@
       min-width="500px"
     >
       <!-- Add Reset Zoom Icon -->
-      <v-btn
-        class="zoom-button"
-        color="#f4f4f4"
-        outlined
-        @click="resetZoom()"
-        style="position: absolute; top: 110px; right: 10px; z-index: 10;"
-        >
-        <v-icon :icon="mdiMagnifyMinusOutline" class="me-2"></v-icon>
+      <v-tooltip>
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            color="input"
+            size="small"
+            @click="resetZoom()"
+            style="position: absolute; top: 110px; right: 10px; z-index: 10;"
+            :icon="mdiMagnifyMinusOutline"
+          >
+          </v-btn>
+        </template>
         RESET ZOOM
-      </v-btn> 
+      </v-tooltip>
       <!-- Chart -->
       <Line :data="chartData" :options="options" ref="activeReachChart" />
     </v-sheet>
@@ -227,6 +231,14 @@ const options = {
   },
   onClick: (e) => handleTimeseriesPointClick(e)
 }
+
+const resetZoom = () => {
+  if (activeReachChart.value?.chart?.resetZoom) {
+    activeReachChart.value.chart.resetZoom();
+  } else {
+    console.error('Chart instance not found or resetZoom method is unavailable.');
+  }
+};
 
 const handleTimeseriesPointClick = (e) => {
   const elems = activeReachChart.value.chart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, false)

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -7,16 +7,20 @@
       min-width="500px"
     >
       <!-- Add Reset Zoom Icon -->
-      <v-btn
-        class="zoom-button"
-        color="#f4f4f4"
-        outlined
-        @click="resetZoom()"
-        style="position: absolute; top: 80px; right: 520px; z-index: 10;"
-        >
-        <v-icon :icon="mdiMagnifyMinusOutline" class="me-2"></v-icon>
+      <v-tooltip>
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            color="input"
+            size="small"
+            @click="resetZoom()"
+            style="position: absolute; top: 80px; right: 45px; z-index: 10;"
+            :icon="mdiMagnifyMinusOutline"
+          >
+          </v-btn>
+        </template>
         RESET ZOOM
-      </v-btn> 
+      </v-tooltip>
       <!-- Chart -->
       <Line :data="nodeChartData" :options="options" ref="activeNodeChart" :plugins="[Filler]" />
     </v-sheet>
@@ -31,6 +35,7 @@ import { nextTick, onMounted } from 'vue'
 import { useDisplay } from 'vuetify'
 import { useChartsStore } from '@/stores/charts'
 import { storeToRefs } from 'pinia'
+import { mdiChartBellCurveCumulative, mdiCloseBox, mdiMagnifyMinusOutline } from '@mdi/js'
 
 const { lgAndUp } = useDisplay()
 
@@ -56,6 +61,14 @@ onMounted(async () => {
   chartStore.storeMountedChart(activeNodeChart.value)
   chartStore.updateShowLine()
 })
+
+const resetZoom = () => {
+  if (activeNodeChart.value?.chart?.resetZoom) {
+    activeNodeChart.value.chart.resetZoom();
+  } else {
+    console.error('Chart instance not found or resetZoom method is unavailable.');
+  }
+};
 
 const getParsing = () => {
   let parsing = {}

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -70,47 +70,29 @@ const options = {
   parsing: getParsing,
   plugins: {
     legend: {
-      display: false,
-      position: 'bottom',
-      labels: {
-        // hide the q0.75 series from the legend. This is because the interquartile range
-        // will be toggled by a single series. We'll use q0.25 for this.
-        filter: (item) => item.text !== 'q0.75'
-      },
-      onClick: function (e, legendItem, legend) {
-        const index = legendItem.datasetIndex
-        const ci = legend.chart
-
-        if (legendItem.text == 'IQR') {
-          // toggle the IQR data series
-          toggleByIndex(index)
-
-          // toggle the q0.75 data series that is not displayed in the legend. This will make
-          // IQR appear as a patch instead of a line.
-          let isHidden = activeNodeChart.value.chart.data.datasets.filter((d) => d.label == 'q0.75')[0].hidden
-          activeNodeChart.value.chart.data.datasets.filter((d) => d.label == 'q0.75')[0].hidden = !isHidden
-          activeNodeChart.value.chart.update()
-        } else {
-          toggleByIndex(index)
-        }
-
-        function toggleByIndex(index) {
-          if (ci.isDatasetVisible(index)) {
-            ci.hide(index)
-            legendItem.hidden = true
-          } else {
-            ci.show(index)
-            legendItem.hidden = false
-          }
-        }
-      }
-    },
-    title: {
       display: true,
-      text: title,
-      font: {
-        size: 16
-      }
+      position: 'top',
+      align : 'end',
+      labels: {
+        usePointStyle: true,
+        generateLabels: () => chartStore.generateDataQualityLegend(),
+        font: {
+          size: 12,
+        },
+        boxWidth: 20,
+        padding: 10,
+      },
+      title: {
+        display: true,
+        text: 'Data Quality',
+        font: {
+          size: 16,
+          weight: 'bold',
+        },
+        padding: {
+          top: 10,
+        },
+      },
     },
     customCanvasBackgroundColor: {
       color: 'white'

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -8,6 +8,18 @@
           max-width="100%"
           min-width="500px"
         >
+        <!-- Add Reset Zoom Icon -->
+        <v-btn
+          class="zoom-button"
+          color="#f4f4f4"
+          outlined
+          @click="resetZoom()"
+          style="position: absolute; top: 80px; right: 520px; z-index: 10;"
+          >
+          <v-icon :icon="mdiMagnifyMinusOutline" class="me-2"></v-icon>
+          RESET ZOOM
+        </v-btn> 
+        <!-- Chart -->
           <Line :data="nodeChartData" :options="options" ref="nodeChart" :plugins="[Filler]" />
         </v-sheet>
         <v-sheet class="pa-2" color="input">

--- a/frontend/src/components/NodeChart.vue
+++ b/frontend/src/components/NodeChart.vue
@@ -48,14 +48,14 @@
                   <v-icon :icon="mdiCodeJson"></v-icon>
                   Download JSON
                 </v-btn>
-                <v-btn @click="resetZoom()" color="input" class="ma-1">
+                <!-- <v-btn @click="resetZoom()" color="input" class="ma-1">
                   <v-icon :icon="mdiMagnifyMinusOutline"></v-icon>
                   Zoom to Exent
-                </v-btn>
-                <v-btn @click="resetData()" color="input" class="ma-1">
+                </v-btn> -->
+                <!-- <v-btn @click="resetData()" color="input" class="ma-1">
                   <v-icon :icon="mdiEraser"></v-icon>
                   Reset Data
-                </v-btn>
+                </v-btn> -->
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>

--- a/frontend/src/stores/charts.js
+++ b/frontend/src/stores/charts.js
@@ -822,5 +822,6 @@ export const useChartsStore = defineStore('charts', () => {
     generateDataQualityLegend,
     activeNodeChart,
     activeReachChart,
+    updateNodeDataSetStyles,
   }
 })

--- a/frontend/src/stores/charts.js
+++ b/frontend/src/stores/charts.js
@@ -41,6 +41,17 @@ export const useChartsStore = defineStore('charts', () => {
     { value: 3, label: 'bad', pointStyle: 'rectRot', pointBorderColor: 'red', icon: mdiRhombus }
   ]
 
+  const generateDataQualityLegend = () => {
+    return dataQualityOptions.map((option) => ({
+      text: option.label,
+      fillStyle: option.pointBorderColor,
+      strokeStyle: option.pointBorderColor,
+      pointStyle: option.pointStyle,
+      strokeStyle: 'black',
+      lineWidth: 2,
+    }));
+  };
+
   // load the swot variables from the hydrologic store.
   // these are used to build the charts for the node and reach views.
   const hydrologicStore = useHydrologicStore()
@@ -746,6 +757,7 @@ export const useChartsStore = defineStore('charts', () => {
     showLine,
     updateShowLine,
     storeMountedChart,
-    activePlt
+    activePlt,
+    generateDataQualityLegend
   }
 })

--- a/frontend/src/stores/hydrologic.js
+++ b/frontend/src/stores/hydrologic.js
@@ -549,6 +549,8 @@ export const useHydrologicStore = defineStore('hydrologic', () => {
         const displayKey = found.swotviz_alias || found.short_definition // Use alias if available
         if (found.mapping && found.mapping[val]) {
             displayValue = found.mapping[val];
+        } else if (typeof val === 'string' && val.includes(' ')) {
+            displayValue = val.split(' ').join(', ');
         } else {
             const isNumber = !isNaN(parseFloat(val)) && isFinite(val)
             displayValue = isNumber


### PR DESCRIPTION
List of changes:

- Defined the `generateDataQualityLegend` function in `charts.js` to generate labels for all data quality levels that are used in the plot legend.
- Switched on the legend plugin and used the `generateDataQualityLegend` function to generate labels for the data quality legend. This is currently used only for the timeseries plots. 
- Add a legend title ("Data Quality") 
- Removed the "RESET ZOOM" from the Plot Actions. 
- Added the "RESET ZOOM" button as an overlay element on both plots. They are positioned in the top-right corner. 