### PR TITLE
Cam 461/wse vs reach for timeseries view

### DIFF
--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -147,11 +147,12 @@ const getParsing = () => {
 
   parsing.xAxisKey = plt.xvar.abbreviation
   parsing.yAxisKey = plt.yvar.abbreviation
+   
   return parsing
 }
 
 const getXScale = () => {
-  let xvar_abbr = plt.xvar.abbreviation
+  let xvar_abbr = props.chosenPlot.xvar.abbreviation
   if (xvar_abbr == 'time_str') {
     return {
       type: 'time',

--- a/frontend/src/components/LineChart.vue
+++ b/frontend/src/components/LineChart.vue
@@ -150,6 +150,30 @@ const getParsing = () => {
   return parsing
 }
 
+const getXScale = () => {
+  let xvar_abbr = plt.xvar.abbreviation
+  if (xvar_abbr == 'time_str') {
+    return {
+      type: 'time',
+      time: {
+        locale: enUS
+      },
+      title: {
+        display: true,
+        text: xLabel
+      }
+    }
+  } else {
+    return {
+      type: 'linear',
+      title: {
+        display: true,
+        text: xLabel
+      }
+    }
+  }
+}
+
 const options = {
   responsive: true,
   maintainAspectRatio: false,
@@ -216,20 +240,7 @@ const options = {
     }
   },
   scales: {
-    x: {
-      type: 'time',
-      time: {
-        // unit: 'day',
-        // displayFormats: {
-        //   day: 'MM.dd'
-        // },
-        locale: enUS
-      },
-      title: {
-        display: true,
-        text: xLabel
-      }
-    },
+    x: getXScale(),
     y: {
       title: {
         display: true,

--- a/frontend/src/stores/charts.js
+++ b/frontend/src/stores/charts.js
@@ -71,14 +71,6 @@ export const useChartsStore = defineStore('charts', () => {
       title: 'Reach Width along Reach Length',
       help: "Reach Width plotted against Reach Length for all nodes in the selected reach",
       name: 'Width vs Distance',
-    },
-    {
-      abbreviation: 'wse/width',
-      xvar: swotVariables.value.find((v) => v.abbreviation == 'width'),
-      yvar: swotVariables.value.find((v) => v.abbreviation == 'wse'),
-      title: 'Water Surface Elevation vs Reach Width',
-      help: "Water Surface Elevation plotted against Reach Width for all nodes in the selected reach",
-      name: 'WSE vs Width',
     }
   ])
 
@@ -117,6 +109,14 @@ export const useChartsStore = defineStore('charts', () => {
       title: 'Reach Slope',
       help: swotVariables.value.find((v) => v.abbreviation == 'slope').definition,
       name: 'Slope vs Time',
+    },
+    {
+      abbreviation: 'wse/width',
+      xvar: swotVariables.value.find((v) => v.abbreviation == 'width'),
+      yvar: swotVariables.value.find((v) => v.abbreviation == 'wse'),
+      title: 'Water Surface Elevation vs Reach Width',
+      help: "Water Surface Elevation plotted against Reach Width for all nodes in the selected reach",
+      name: 'WSE vs Width',
     }
   ])
 

--- a/frontend/src/views/TimeSeriesCharts.vue
+++ b/frontend/src/views/TimeSeriesCharts.vue
@@ -75,7 +75,31 @@ onMounted(() => {
   }
 })
 
+const sortChartByX = (plt) => {
+  // grab the chart data from the store and maintain reactivity
+  const {chartData} = storeToRefs(chartStore)
+ 
+  // get the chart data and sort it by the x-axis variable.
+  // If the x-axis variable is time, sort by time otherwise
+  // sort numerically.
+  let plotData = chartData.value.datasets[0].data
+  let xvar = plt.xvar.abbreviation
+
+  if (xvar == 'time_str') {
+    plotData = plotData.sort((a,b) => new Date(a.time_str) - new Date(b.time_str));
+  }
+  else {
+    plotData = plotData.sort((a,b) => parseFloat(a[xvar]) - parseFloat(b[xvar]));
+  }
+  chartStore.updateShowLine()
+
+}
+
 const changePlot = (plt) => {
+  // re-sort the chart data by the x-axis variable
+  // before rending the chart
+  sortChartByX(plt)
+
   router.push({ query: { ...router.currentRoute.value.query, variables: plt.abbreviation } })
 }
 


### PR DESCRIPTION
Changes:

1. Moved WSW vs Width from the node profile graph to the reach timeseries graph.
2. Added a function to sort timeseries graph data along the x-axis before its rendered.