### PR TITLE
CAM-1319: Update metadata panel bug

### DIFF
--- a/frontend/src/components/DataViewDrawer.vue
+++ b/frontend/src/components/DataViewDrawer.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useFeaturesStore } from '@/stores/features'
 import { mdiChevronRight, mdiChevronLeft, mdiChartScatterPlot } from '@mdi/js'
 import StaticMetadata from './StaticMetadata.vue'
@@ -55,12 +55,14 @@ const hasResults = () => {
   return featureStore?.activeFeature?.results !== undefined
 }
 
-featureStore.$subscribe((mutation, state) => {
-  if (state.activeFeature !== null) {
-    // && typeof mutation.events.newValue === 'object'
-    show.value = true
+watch(
+  () => featureStore.activeFeature?.properties?.feature_id,
+  (newId, oldId) => {
+    if (newId != null && newId !== oldId) {
+      show.value = true
+    }
   }
-})
+)
 </script>
 
 <style scoped>

--- a/frontend/src/components/TheLeafletMap.vue
+++ b/frontend/src/components/TheLeafletMap.vue
@@ -532,6 +532,7 @@ function clearSelection() {
 
   featureStore.clearSelectedFeatures()
   chartStore.clearChartData()
+  featureStore.activeFeature = null
 
   // update the map
   updateMapBBox()


### PR DESCRIPTION
Update the metadata sidebar for SWOT viewer so closing it clears the map’s selection state