### PR TITLE
Return empty series instead of an HTTP 500 when compute_node_series has no observations

### DIFF
--- a/api/requirements-dev.txt
+++ b/api/requirements-dev.txt
@@ -2,3 +2,4 @@ isort==5.13.2
 black==24.4.2
 debugpy==1.8.2
 epdb
+pytest==8.2.2

--- a/api/swotvis/app/routers/data/router.py
+++ b/api/swotvis/app/routers/data/router.py
@@ -36,9 +36,17 @@ async def compute_node_series(data: List[List[SwotNodeDataModel]]):
     # from HydroCron.
     series = SwotNodeDataSeriesModel(all_series=data)
 
+    df = series.as_dataframe()
+
+    # With no observations to summarize, the dataframe has no node-variable
+    # columns and the selection below raises a KeyError -> HTTP 500. Return
+    # empty series in that case instead.
+    if df.empty:
+        return {"median": [], "q0.25": [], "q0.75": []}
+
     # group all data by p_dist_out and remove all columns except
     # those corresponding to node variables
-    grouped = series.as_dataframe()[NodeVariables.list()].groupby("p_dist_out")
+    grouped = df[NodeVariables.list()].groupby("p_dist_out")
 
     # Compute node-level statistics. Replace np.nan with None because np.nan
     # is not JSON serializable. Convert all pandas dataframes to dictionaries

--- a/api/swotvis/tests/test_compute_node_series.py
+++ b/api/swotvis/tests/test_compute_node_series.py
@@ -1,0 +1,80 @@
+"""Tests for the /data/compute_node_series statistics endpoint.
+
+Run with the repo's `make test` target (docker compose exec api pytest tests),
+or directly from the api/swotvis directory with `PYTHONPATH=. pytest tests`.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.data import router as data_router
+
+
+def _client():
+    app = FastAPI()
+    app.include_router(data_router, prefix="/data")
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _observation(p_dist_out, wse, width, area_total, time_str):
+    return {
+        "time_str": time_str,
+        "node_q": 1,
+        "p_dist_out": p_dist_out,
+        "wse": wse,
+        "width": width,
+        "area_total": area_total,
+        "wse_units": "m",
+        "width_units": "m",
+        "area_total_units": "m^2",
+        "p_dist_out_units": "m",
+        "datetime": time_str,
+    }
+
+
+def test_compute_node_series_summarizes_observations_by_distance():
+    client = _client()
+    # Two observations at p_dist_out=100 (wse 10 and 20) and one at 200.
+    data = [
+        [
+            _observation(100.0, 10.0, 50.0, 500.0, "2024-01-01T00:00:00Z"),
+            _observation(100.0, 20.0, 60.0, 600.0, "2024-01-08T00:00:00Z"),
+            _observation(200.0, 30.0, 70.0, 700.0, "2024-01-01T00:00:00Z"),
+        ]
+    ]
+
+    response = client.post("/data/compute_node_series", json=data)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body.keys()) == {"median", "q0.25", "q0.75"}
+
+    median = {row["p_dist_out"]: row for row in body["median"]}
+    assert median[100.0]["wse"] == 15.0
+    assert median[100.0]["width"] == 55.0
+    assert median[200.0]["wse"] == 30.0
+
+    q25 = {row["p_dist_out"]: row for row in body["q0.25"]}
+    q75 = {row["p_dist_out"]: row for row in body["q0.75"]}
+    assert q25[100.0]["wse"] == 12.5
+    assert q75[100.0]["wse"] == 17.5
+
+
+def test_compute_node_series_empty_body_returns_empty_series():
+    # Regression: an empty request body used to raise a KeyError -> HTTP 500.
+    client = _client()
+
+    response = client.post("/data/compute_node_series", json=[])
+
+    assert response.status_code == 200
+    assert response.json() == {"median": [], "q0.25": [], "q0.75": []}
+
+
+def test_compute_node_series_series_without_observations_returns_empty_series():
+    # Regression: a series carrying no observations used to raise a 500 too.
+    client = _client()
+
+    response = client.post("/data/compute_node_series", json=[[]])
+
+    assert response.status_code == 200
+    assert response.json() == {"median": [], "q0.25": [], "q0.75": []}


### PR DESCRIPTION
This PR proposes fixing an HTTP 500 in the `/data/compute_node_series` node-statistics endpoint when it receives no observations, and adding the backend `pytest` suite that your `make test` target runs. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/198. You can sign in with your GitHub ID to claim ownership of the project.

## The fix

When a request to `POST /data/compute_node_series` carries no node observations — an empty body `[]`, or a series with no points `[[]]` — `SwotNodeDataSeriesModel.as_dataframe()` builds an empty `DataFrame` with no columns, and the very next `[NodeVariables.list()]` column selection raises a `KeyError`, which FastAPI surfaces to the caller as a 500.

Reproduced on `develop` at HEAD (`fddb1e0`), using the same `python:3.10` / `pandas==2.2.2` / `fastapi==0.111.1` the API container pins:

```
POST /data/compute_node_series  json=[]        -> HTTP 500  (KeyError)
POST /data/compute_node_series  json=[[]]      -> HTTP 500  (KeyError)
POST /data/compute_node_series  json=[<obs>]   -> HTTP 200  (correct median / q0.25 / q0.75)
```

The traceback is `KeyError: "None of [Index(['wse', 'width', 'area_total', 'p_dist_out'], dtype='object')] are in the [columns]"`.

The statistics feature reaches this endpoint from `stores/stats.js` `getStatistics()`, which posts the visible `swot_node_series` datasets' points; that list is empty whenever no node series is currently visible, or when time-range / data-quality filtering has removed every point. Your open PR #210 already adds a front-end guard for one of these paths (`recomputeStatsAndUpdateCharts`), which is what pointed me at the failure mode — this change is complementary and hardens the endpoint itself, so the API no longer 500s regardless of what the client sends.

The fix materializes the dataframe once and, when it is empty, returns `{"median": [], "q0.25": [], "q0.75": []}` — the same response shape as the success path, so the front end's `generateStatisticsSeries` loop simply builds no series. The non-empty path is unchanged, so existing behavior is preserved.

I also added the `api/swotvis/tests/` suite that your `Makefile` `test` target (`docker compose exec api pytest tests`) already invokes but which did not exist yet, and added `pytest` to `requirements-dev.txt`. The suite covers the normal computation (median = 15.0 and quartiles 12.5 / 17.5 for two observations of 10 and 20 at one distance) plus the two empty-input regressions.

Verification: the new tests fail against current `develop` (`2 failed, 1 passed` — the empty-input cases 500) and pass with the fix (`3 passed`), run exactly as `make test` runs them (`pytest tests` from `/swotvis`). Your pinned `isort==5.13.2` and `black -S -l 120` report no changes on the touched files. The rest of the repo is untouched — this is a backend-only change.

## How this was managed

This work was tracked as a story on a live agile board we imported from this repository's own issues and pull requests (217 stories, 8 labels): https://eastagiletracker.com/projects/198/stories/62015 — and the board itself, showing your project's history, lives at https://eastagiletracker.com/projects/198.

![board](https://raw.githubusercontent.com/eastagiletracker/SWOT-Data-Viewer/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
